### PR TITLE
Fix form type of `providers[].prefix`

### DIFF
--- a/src/components/items/Providers.tsx
+++ b/src/components/items/Providers.tsx
@@ -62,7 +62,7 @@ export default function Extensions() {
                         </label>
                         <div className="relative w-full">
                         <input
-                            type="number"
+                            type="text"
                             id={"providers[" + idx + "].prefix"}
                             className="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5"
                             onChange={
@@ -70,7 +70,7 @@ export default function Extensions() {
                                     draft.data.providers[idx].prefix = e.target.value
                                 })
                             }
-                            value={val.prefix}
+                            value={val.prefix ?? ""}
                         />
                         </div>
                     </div>


### PR DESCRIPTION
fix: #20 

|before|after|
|---|---|
|<img width="322" height="80" alt="image" src="https://github.com/user-attachments/assets/dd485202-a794-46ac-a0e9-b1cd525ffdbc" />|<img width="307" height="90" alt="image" src="https://github.com/user-attachments/assets/18ed111e-14e2-44be-9a97-9dfa6c146ac9" />|