### PR TITLE
Replace mantela spec link

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -17,7 +17,7 @@ export default function Footer() {
 						</a>
 					</li>
 					<li>
-						<a href="https://tkytel.github.io/mantela" className="hover:underline me-4 md:me-6">
+						<a href="https://tkytel.github.io/mantela/MANTELA" className="hover:underline me-4 md:me-6">
 							Mantela
 						</a>
 					</li>


### PR DESCRIPTION
フッターの「Mantela」リンクを差し替えました。
旧: https://tkytel.github.io/mantela
新: https://tkytel.github.io/mantela/MANTELA