### PR TITLE
Chunk manually to reduce size of bundled js files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,5 @@ dist-ssr
 
 *storybook.log
 storybook-static
+
+stats.html

--- a/bun.lock
+++ b/bun.lock
@@ -39,6 +39,7 @@
         "eslint-plugin-jsx-a11y": "^6.10.2",
         "eslint-plugin-perfectionist": "^4.15.0",
         "eslint-plugin-react-refresh": "^0.4.20",
+        "eslint-plugin-unused-imports": "^4.2.0",
         "globals": "^15.15.0",
         "jotai-devtools": "^0.11.0",
         "js-beautify": "^1.15.4",
@@ -982,6 +983,8 @@
     "eslint-plugin-react-refresh": ["eslint-plugin-react-refresh@0.4.20", "", { "peerDependencies": { "eslint": ">=8.40" } }, "sha512-XpbHQ2q5gUF8BGOX4dHe+71qoirYMhApEPZ7sfhF/dNnOF1UXnCMGZf79SFTBO7Bz5YEIT4TMieSlJBWhP9WBA=="],
 
     "eslint-plugin-unicorn": ["eslint-plugin-unicorn@59.0.1", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.25.9", "@eslint-community/eslint-utils": "^4.5.1", "@eslint/plugin-kit": "^0.2.7", "ci-info": "^4.2.0", "clean-regexp": "^1.0.0", "core-js-compat": "^3.41.0", "esquery": "^1.6.0", "find-up-simple": "^1.0.1", "globals": "^16.0.0", "indent-string": "^5.0.0", "is-builtin-module": "^5.0.0", "jsesc": "^3.1.0", "pluralize": "^8.0.0", "regexp-tree": "^0.1.27", "regjsparser": "^0.12.0", "semver": "^7.7.1", "strip-indent": "^4.0.0" }, "peerDependencies": { "eslint": ">=9.22.0" } }, "sha512-EtNXYuWPUmkgSU2E7Ttn57LbRREQesIP1BiLn7OZLKodopKfDXfBUkC/0j6mpw2JExwf43Uf3qLSvrSvppgy8Q=="],
+
+    "eslint-plugin-unused-imports": ["eslint-plugin-unused-imports@4.2.0", "", { "peerDependencies": { "@typescript-eslint/eslint-plugin": "^8.0.0-0 || ^7.0.0 || ^6.0.0 || ^5.0.0", "eslint": "^9.0.0 || ^8.0.0" }, "optionalPeers": ["@typescript-eslint/eslint-plugin"] }, "sha512-hLbJ2/wnjKq4kGA9AUaExVFIbNzyxYdVo49QZmKCnhk5pc9wcYRbfgLHvWJ8tnsdcseGhoUAddm9gn/lt+d74w=="],
 
     "eslint-rule-docs": ["eslint-rule-docs@1.1.235", "", {}, "sha512-+TQ+x4JdTnDoFEXXb3fDvfGOwnyNV7duH8fXWTPD1ieaBmB8omj7Gw/pMBBu4uI2uJCCU8APDaQJzWuXnTsH4A=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -44,6 +44,7 @@
         "js-beautify": "^1.15.4",
         "postcss": "^8.5.3",
         "postcss-import": "^16.1.0",
+        "rollup-plugin-visualizer": "^6.0.3",
         "storybook": "^9.1.4",
         "tailwindcss": "3",
         "typescript": "~5.7.2",
@@ -1634,6 +1635,8 @@
 
     "rollup": ["rollup@4.50.1", "", { "dependencies": { "@types/estree": "1.0.8" }, "optionalDependencies": { "@rollup/rollup-android-arm-eabi": "4.50.1", "@rollup/rollup-android-arm64": "4.50.1", "@rollup/rollup-darwin-arm64": "4.50.1", "@rollup/rollup-darwin-x64": "4.50.1", "@rollup/rollup-freebsd-arm64": "4.50.1", "@rollup/rollup-freebsd-x64": "4.50.1", "@rollup/rollup-linux-arm-gnueabihf": "4.50.1", "@rollup/rollup-linux-arm-musleabihf": "4.50.1", "@rollup/rollup-linux-arm64-gnu": "4.50.1", "@rollup/rollup-linux-arm64-musl": "4.50.1", "@rollup/rollup-linux-loongarch64-gnu": "4.50.1", "@rollup/rollup-linux-ppc64-gnu": "4.50.1", "@rollup/rollup-linux-riscv64-gnu": "4.50.1", "@rollup/rollup-linux-riscv64-musl": "4.50.1", "@rollup/rollup-linux-s390x-gnu": "4.50.1", "@rollup/rollup-linux-x64-gnu": "4.50.1", "@rollup/rollup-linux-x64-musl": "4.50.1", "@rollup/rollup-openharmony-arm64": "4.50.1", "@rollup/rollup-win32-arm64-msvc": "4.50.1", "@rollup/rollup-win32-ia32-msvc": "4.50.1", "@rollup/rollup-win32-x64-msvc": "4.50.1", "fsevents": "~2.3.2" }, "bin": { "rollup": "dist/bin/rollup" } }, "sha512-78E9voJHwnXQMiQdiqswVLZwJIzdBKJ1GdI5Zx6XwoFKUIk09/sSrr+05QFzvYb8q6Y9pPV45zzDuYa3907TZA=="],
 
+    "rollup-plugin-visualizer": ["rollup-plugin-visualizer@6.0.3", "", { "dependencies": { "open": "^8.0.0", "picomatch": "^4.0.2", "source-map": "^0.7.4", "yargs": "^17.5.1" }, "peerDependencies": { "rolldown": "1.x || ^1.0.0-beta", "rollup": "2.x || 3.x || 4.x" }, "optionalPeers": ["rolldown", "rollup"], "bin": { "rollup-plugin-visualizer": "dist/bin/cli.js" } }, "sha512-ZU41GwrkDcCpVoffviuM9Clwjy5fcUxlz0oMoTXTYsK+tcIFzbdacnrr2n8TXcHxbGKKXtOdjxM2HUS4HjkwIw=="],
+
     "run-applescript": ["run-applescript@7.1.0", "", {}, "sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q=="],
 
     "run-parallel": ["run-parallel@1.2.0", "", { "dependencies": { "queue-microtask": "^1.2.2" } }, "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA=="],
@@ -1686,7 +1689,7 @@
 
     "smtp-address-parser": ["smtp-address-parser@1.0.10", "", { "dependencies": { "nearley": "^2.20.1" } }, "sha512-Osg9LmvGeAG/hyao4mldbflLOkkr3a+h4m1lwKCK5U8M6ZAr7tdXEz/+/vr752TSGE4MNUlUl9cIK2cB8cgzXg=="],
 
-    "source-map": ["source-map@0.6.1", "", {}, "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="],
+    "source-map": ["source-map@0.7.6", "", {}, "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ=="],
 
     "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
 
@@ -2061,6 +2064,8 @@
     "public-encrypt/bn.js": ["bn.js@4.12.2", "", {}, "sha512-n4DSx829VRTRByMRGdjQ9iqsN0Bh4OolPsFnaZBLcbi8iXcB+kJ9s7EnRt4wILZNV3kPLHkRVfOc/HvhC3ovDw=="],
 
     "readdirp/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
+
+    "recast/source-map": ["source-map@0.6.1", "", {}, "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="],
 
     "redent/indent-string": ["indent-string@4.0.0", "", {}, "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg=="],
 

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "js-beautify": "^1.15.4",
     "postcss": "^8.5.3",
     "postcss-import": "^16.1.0",
+    "rollup-plugin-visualizer": "^6.0.3",
     "storybook": "^9.1.4",
     "tailwindcss": "3",
     "typescript": "~5.7.2",

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "eslint-plugin-jsx-a11y": "^6.10.2",
     "eslint-plugin-perfectionist": "^4.15.0",
     "eslint-plugin-react-refresh": "^0.4.20",
+    "eslint-plugin-unused-imports": "^4.2.0",
     "globals": "^15.15.0",
     "jotai-devtools": "^0.11.0",
     "js-beautify": "^1.15.4",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,3 +1,4 @@
+import { visualizer } from "rollup-plugin-visualizer";
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react-swc";
 import flowbiteReact from "flowbite-react/plugin/vite";
@@ -6,8 +7,26 @@ import { nodePolyfills } from "vite-plugin-node-polyfills";
 // https://vite.dev/config/
 export default defineConfig({
 	base: "/mantela-editor/",
+	build: {
+		chunkSizeWarningLimit: 550,
+		rollupOptions: {
+			output: {
+				manualChunks: {
+					codemirror: [
+						"@codemirror/autocomplete",
+						"@codemirror/lint",
+						"@codemirror/view",
+						"@codemirror/commands",
+						"@codemirror/lang-json",
+					],
+					codemirrorJsonSchema: ["codemirror-json-schema"],
+					react: ["react", "react-dom/client"],
+				},
+			},
+		},
+	},
 	plugins: [
-		react({}),
+		...react(),
 		flowbiteReact(),
 		// NOTE: @apidevtools/json-schema-ref-parser をブラウザで動かすため。
 		nodePolyfills({
@@ -18,5 +37,6 @@ export default defineConfig({
 			},
 			include: ["path"],
 		}),
+		visualizer(),
 	],
 });

--- a/xo.config.mjs
+++ b/xo.config.mjs
@@ -2,6 +2,7 @@ import globals from "globals";
 import jsxA11y from "eslint-plugin-jsx-a11y";
 import perfectionist from "eslint-plugin-perfectionist";
 import reactRefresh from "eslint-plugin-react-refresh";
+import unusedImports from "eslint-plugin-unused-imports";
 
 /** @type import('xo').FlatXoConfig */
 const xoConfig = [
@@ -25,6 +26,7 @@ const xoConfig = [
 		plugins: {
 			perfectionist,
 			"react-refresh": reactRefresh,
+			"unused-imports": unusedImports,
 		},
 		prettier: true,
 		rules: {
@@ -38,7 +40,7 @@ const xoConfig = [
 			"@typescript-eslint/naming-convention": "off",
 			"@typescript-eslint/no-dynamic-delete": "off",
 			"@typescript-eslint/no-unsafe-call": "off",
-			"@typescript-eslint/no-unused-vars": ["warn", { argsIgnorePattern: "^_", varsIgnorePattern: "^_" }],
+			"@typescript-eslint/no-unused-vars": "off",
 			"@typescript-eslint/triple-slash-reference": "off",
 
 			"import-x/extensions": "off",
@@ -51,10 +53,21 @@ const xoConfig = [
 			"perfectionist/sort-imports": "off",
 
 			"react-refresh/only-export-components": ["warn", { allowConstantExport: true }],
+
 			"unicorn/filename-case": "off",
 			"unicorn/prefer-module": "off",
-
 			"unicorn/prevent-abbreviations": "off",
+
+			"unused-imports/no-unused-imports": "error",
+			"unused-imports/no-unused-vars": [
+				"warn",
+				{
+					args: "after-used",
+					argsIgnorePattern: "^_",
+					vars: "all",
+					varsIgnorePattern: "^_",
+				},
+			],
 		},
 	},
 	{


### PR DESCRIPTION
fix: #49 

バンドルされたJSファイルを適切に分割し、1ファイルごとのサイズを減らした。

```shellsession
❯ bun run build
$ tsc -b && vite build
vite v6.3.6 building for production...
Generating .flowbite-react/class-list.json file...
✓ 685 modules transformed.
dist/index.html                                 1.43 kB │ gzip:   0.62 kB
dist/assets/index-DlPyfWHV.css                 17.16 kB │ gzip:   3.86 kB
dist/assets/vitesse-light-CVO1_9PV.js          13.62 kB │ gzip:   3.04 kB
dist/assets/vitesse-dark-D0r3Knsf.js           13.76 kB │ gzip:   3.06 kB
dist/assets/react-EaQ_J9ZH.js                 185.25 kB │ gzip:  58.37 kB
dist/assets/javascript-ySlJ1b_l.js            198.03 kB │ gzip:  17.45 kB
dist/assets/index-_CjHl4P5.js                 313.36 kB │ gzip: 102.03 kB
dist/assets/codemirror-VHkxOH41.js            390.00 kB │ gzip: 127.21 kB
dist/assets/codemirrorJsonSchema-B5uDU5gP.js  501.26 kB │ gzip: 168.44 kB
✓ built in 2.26s
```

