### PR TITLE
Change default mantela json from `0.1` / `0.1.0` into `0.1.x`

### DIFF
--- a/src/helpers/Jotai.ts
+++ b/src/helpers/Jotai.ts
@@ -1,7 +1,7 @@
 import { atomWithImmer } from "jotai-immer";
 import type { Mantela } from "../types/mantela";
 
-export const defaultMantelaSchemaUrl = "https://tkytel.github.io/mantela/0.1/mantela.schema.json";
+export const defaultMantelaSchemaUrl = "https://tkytel.github.io/mantela/0.1.x/mantela.schema.json";
 
 export const getInitialMantela = (): Mantela => ({
 	$schema: defaultMantelaSchemaUrl,
@@ -13,7 +13,7 @@ export const getInitialMantela = (): Mantela => ({
 	},
 	extensions: [],
 	providers: [],
-	version: "0.1.0",
+	version: "0.1.x",
 });
 
 export const BodyAtom = atomWithImmer({


### PR DESCRIPTION
> [!NOTE]
> https://github.com/tkytel/mantela/pull/20 のデプロイ後マージ。

fix: #58 

[仕様](https://github.com/tkytel/mantela/wiki/version)に反した規定値を修正。
> 現時点（2025-06-02）の Mantela のバージョンは 0.1.x であるため、`"0.1.x"` を指定します。
ここで、x の部分にはそのまま x を指定します（何らかの数の置き換えではありません）。